### PR TITLE
Add new option 'namespace'

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ limiters[id].get(function(err, limit, remaining, reset) {
   - `id` Unique identifier (API key, IP address or user ID)
   - `limit` Number of tokens
   - `duration` Duration in milliseconds
+  - `namespace` (optional) Overwrite key prefix
+    (defaults to `ratelimit:`)
+    (actual redis key is `namespace + id`)
   
 ## Test
 

--- a/index.js
+++ b/index.js
@@ -8,6 +8,11 @@ var LOCK_TTL = 300; // ms
 // when locked, try again after this delay
 var RETRY_DELAY = 20; // ms
 
+// default values
+var DEFAULTS = {
+  namespace: 'ratelimit:'
+};
+
 // exports
 module.exports = RateLimit;
 
@@ -21,6 +26,7 @@ function RateLimit() {
  * @param {Object} redisClient Instance of a redis client
  */
 RateLimit.prototype.init = function (options, redisClient) {
+  var namespace;
   assert(typeof options === 'object', 'Requires `options` object');
   assert(redisClient, 'Requires instance of Redis client');
 
@@ -39,10 +45,15 @@ RateLimit.prototype.init = function (options, redisClient) {
    * Duration in milliseconds
    */
   this.duration = options.duration;
+  /**
+   * @cfg {String} namespace
+   * Namespace to prefix the id with (defaults to <tt>'ratelimit:'</tt>)
+   */
+  namespace = (typeof options.namespace === 'string') ? options.namespace : DEFAULTS.namespace;
   this.redisClient = redisClient;
   this.reset = 0;
   this.remaining = 0;
-  this.storageId = 'ratelimit:' + this.id;
+  this.storageId = namespace + this.id;
 
   assert(this.id, 'options.id required');
   assert(this.limit, 'options.limit required');


### PR DESCRIPTION
Allow to overwrite default key prefix 'ratelimit:'.

Default behaviour is unchanged.
