### PR TITLE
Use ioredis rather than node_redis

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,20 +120,20 @@ RateLimit.prototype.storageGet = function (callback) {
       return callback(err);
     }
 
-    if (res === null || res[2] === 0) {
+    if (res === null || res[2][1] === 0) {
       // res[2] === 0 means already locked, try again later
       return retry.bind(this)();
 
-    } else if (res[1] < 0) {
+    } else if (res[1][1] < 0) {
       // TTL is 0, start new limiter
       this.start();
       this.remaining -= 1;
 
     } else {
       // all good, set .remaining and .reset
-      this.remaining = (res[0] >> 0) - 1;
+      this.remaining = (res[0][1] >> 0) - 1;
       this.reset = new Date();
-      this.reset.setMilliseconds(this.reset.getMilliseconds() + (res[1] >> 0));
+      this.reset.setMilliseconds(this.reset.getMilliseconds() + (res[1][1] >> 0));
     }
 
     this.storageSet(function (err) {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "jasmine-node": "^1.14.5",
     "jshint": "^2.5.10",
-    "redis": "^0.12.1"
+    "ioredis": "^1.15.1"
   },
   "dependencies": {
     "q": "^1.0.1"

--- a/spec/ratelimiterSpec.js
+++ b/spec/ratelimiterSpec.js
@@ -1,12 +1,12 @@
 var assert = require('assert'),
   RateLimiter = require('../index'),
-  redis = require('redis');
+  Redis = require('ioredis');
 
 var ID = 'testlimiter',
   LIMIT = 10,
   DURATION = 30000;
 
-var redisClient = redis.createClient();
+var redisClient = new Redis();
 
 describe('Setup', function () {
   var limiter;


### PR DESCRIPTION
It turns out the strict-rate-limiter package we're using in Zuul doesn't work out-of-the-box with ioredis, due to a difference in the callback response for the `.exec()` function, as described here:
https://github.com/luin/ioredis/wiki/Migrating-from-node_redis

I'm hacking in support for ioredis so that we can use sentinels.
